### PR TITLE
Add bookmarks

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,5 @@
 import os, sys, logging
+import bpy
 
 print("Loading AssetFetch for Blender v0.2.0")
 logging.basicConfig()
@@ -10,6 +11,14 @@ if LIB_PATH not in sys.path:
 	sys.path.insert(0, LIB_PATH)
 
 SCHEMA_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), "json-schema")
+
+
+# This variable is used for the preferences definition.
+# Normally, it is common practice to use __name__ in the preferences class to tell
+# Blender which addon the preferences are meant. But because we don't define
+# the preferences in this init file, we instead pipe the name over to properties/preferences.py
+# using this variable.
+ADDON_NAME = __name__
 
 bl_info = {
 	"name": "assetfetch-blender",

--- a/src/operator/__init__.py
+++ b/src/operator/__init__.py
@@ -9,6 +9,8 @@ from .update_asset_list import *
 from .build_import_plans import *
 from .update_implementations_list import *
 from .execute_import_plan import *
+from .new_provider_bookmark import *
+from .delete_provider_bookmark import *
 
 # Registration and unregistration functions
 
@@ -23,4 +25,7 @@ def unregister():
 		bpy.utils.unregister_class(cl)
 
 
-registration_targets = [AF_OP_InitializeProvider, AF_OP_UpdateAssetList, AF_OP_UpdateImplementationsList, AF_OP_BuildImportPlans, AF_OP_ExecuteImportPlan, AF_OP_ConnectionStatus]
+registration_targets = [
+	AF_OP_InitializeProvider, AF_OP_UpdateAssetList, AF_OP_UpdateImplementationsList, AF_OP_BuildImportPlans, AF_OP_ExecuteImportPlan, AF_OP_ConnectionStatus,
+	AF_OP_NewProviderBookmark, AF_OP_DeleteProviderBookmark
+]

--- a/src/operator/__init__.py
+++ b/src/operator/__init__.py
@@ -11,6 +11,8 @@ from .update_implementations_list import *
 from .execute_import_plan import *
 from .new_provider_bookmark import *
 from .delete_provider_bookmark import *
+from .new_provider_bookmark_header import *
+from .delete_provider_bookmark_header import *
 
 # Registration and unregistration functions
 
@@ -27,5 +29,5 @@ def unregister():
 
 registration_targets = [
 	AF_OP_InitializeProvider, AF_OP_UpdateAssetList, AF_OP_UpdateImplementationsList, AF_OP_BuildImportPlans, AF_OP_ExecuteImportPlan, AF_OP_ConnectionStatus,
-	AF_OP_NewProviderBookmark, AF_OP_DeleteProviderBookmark
+	AF_OP_NewProviderBookmark, AF_OP_DeleteProviderBookmark, AF_OP_DeleteProviderBookmarkHeader, AF_OP_NewProviderBookmarkHeader
 ]

--- a/src/operator/delete_provider_bookmark.py
+++ b/src/operator/delete_provider_bookmark.py
@@ -1,0 +1,8 @@
+import bpy
+
+class AF_OP_DeleteProviderBookmark(bpy.types.Operator):
+	"""Creates a new provider bookmark."""
+
+	bl_idname = "af.delete_provider_bookmark"
+	bl_label = "Delete Bookmark"
+	bl_options = {"REGISTER", "INTERNAL"}

--- a/src/operator/delete_provider_bookmark.py
+++ b/src/operator/delete_provider_bookmark.py
@@ -1,5 +1,5 @@
 import bpy
-from ..property.preferences import addon_preferences
+from ..property.preferences import *
 
 class AF_OP_DeleteProviderBookmark(bpy.types.Operator):
 	"""Creates a new provider bookmark."""
@@ -9,6 +9,7 @@ class AF_OP_DeleteProviderBookmark(bpy.types.Operator):
 	bl_options = {"REGISTER", "INTERNAL"}
 
 	def execute(self, context):
-		addon_preferences().provider_bookmarks.remove(addon_preferences().provider_bookmarks_index)
-		addon_preferences().provider_bookmarks_index = max(0,addon_preferences().provider_bookmarks_index-1)
+		prefs = AF_PR_Preferences.get_prefs()
+		prefs.provider_bookmarks.remove(prefs.provider_bookmarks_index)
+		prefs.provider_bookmarks_index = max(0,prefs.provider_bookmarks_index-1)
 		return {'FINISHED'}

--- a/src/operator/delete_provider_bookmark.py
+++ b/src/operator/delete_provider_bookmark.py
@@ -1,4 +1,5 @@
 import bpy
+from ..property.preferences import addon_preferences
 
 class AF_OP_DeleteProviderBookmark(bpy.types.Operator):
 	"""Creates a new provider bookmark."""
@@ -6,3 +7,8 @@ class AF_OP_DeleteProviderBookmark(bpy.types.Operator):
 	bl_idname = "af.delete_provider_bookmark"
 	bl_label = "Delete Bookmark"
 	bl_options = {"REGISTER", "INTERNAL"}
+
+	def execute(self, context):
+		addon_preferences().provider_bookmarks.remove(addon_preferences().provider_bookmarks_index)
+		addon_preferences().provider_bookmarks_index = max(0,addon_preferences().provider_bookmarks_index-1)
+		return {'FINISHED'}

--- a/src/operator/delete_provider_bookmark_header.py
+++ b/src/operator/delete_provider_bookmark_header.py
@@ -1,0 +1,16 @@
+import bpy
+from ..property.preferences import *
+
+class AF_OP_DeleteProviderBookmarkHeader(bpy.types.Operator):
+	"""Deletes the currently selected header from the provider bookmark."""
+
+	bl_idname = "af.delete_provider_bookmark_header"
+	bl_label = "Delete Bookmark"
+	bl_options = {"REGISTER", "INTERNAL"}
+
+	def execute(self, context):
+		prefs : AF_PR_Preferences = AF_PR_Preferences.get_prefs()
+		current_bookmark = prefs.get_current_bookmark_in_preferences()
+		current_bookmark.header_values.remove(prefs.provider_bookmarks_headers_index)
+		prefs.provider_bookmarks_headers_index = max(0,prefs.provider_bookmarks_headers_index-1)
+		return {'FINISHED'}

--- a/src/operator/new_provider_bookmark.py
+++ b/src/operator/new_provider_bookmark.py
@@ -1,4 +1,5 @@
 import bpy
+from ..property.preferences import addon_preferences
 
 class AF_OP_NewProviderBookmark(bpy.types.Operator):
 	"""Creates a new provider bookmark."""
@@ -6,3 +7,8 @@ class AF_OP_NewProviderBookmark(bpy.types.Operator):
 	bl_idname = "af.new_provider_bookmark"
 	bl_label = "New Bookmark"
 	bl_options = {"REGISTER", "INTERNAL"}
+
+	def execute(self, context):
+		addon_preferences().provider_bookmarks.add()
+		addon_preferences().provider_bookmarks_index = len(addon_preferences().provider_bookmarks) - 1
+		return {'FINISHED'}

--- a/src/operator/new_provider_bookmark.py
+++ b/src/operator/new_provider_bookmark.py
@@ -1,0 +1,8 @@
+import bpy
+
+class AF_OP_NewProviderBookmark(bpy.types.Operator):
+	"""Creates a new provider bookmark."""
+
+	bl_idname = "af.new_provider_bookmark"
+	bl_label = "New Bookmark"
+	bl_options = {"REGISTER", "INTERNAL"}

--- a/src/operator/new_provider_bookmark.py
+++ b/src/operator/new_provider_bookmark.py
@@ -1,5 +1,5 @@
 import bpy
-from ..property.preferences import addon_preferences
+from ..property.preferences import *
 
 class AF_OP_NewProviderBookmark(bpy.types.Operator):
 	"""Creates a new provider bookmark."""
@@ -9,6 +9,7 @@ class AF_OP_NewProviderBookmark(bpy.types.Operator):
 	bl_options = {"REGISTER", "INTERNAL"}
 
 	def execute(self, context):
-		addon_preferences().provider_bookmarks.add()
-		addon_preferences().provider_bookmarks_index = len(addon_preferences().provider_bookmarks) - 1
+		prefs = AF_PR_Preferences.get_prefs()
+		prefs.provider_bookmarks.add()
+		prefs.provider_bookmarks_index = len(prefs.provider_bookmarks) - 1
 		return {'FINISHED'}

--- a/src/operator/new_provider_bookmark_header.py
+++ b/src/operator/new_provider_bookmark_header.py
@@ -1,0 +1,15 @@
+import bpy
+from ..property.preferences import *
+
+class AF_OP_NewProviderBookmarkHeader(bpy.types.Operator):
+	"""Adds a new header to the currently selected provider bookmark."""
+
+	bl_idname = "af.new_provider_bookmark_header"
+	bl_label = "New Header"
+	bl_options = {"REGISTER", "INTERNAL"}
+
+	def execute(self, context):
+		prefs : AF_PR_Preferences = AF_PR_Preferences.get_prefs()
+		current_bookmark = prefs.get_current_bookmark_in_preferences()
+		current_bookmark.header_values.add()
+		return {'FINISHED'}

--- a/src/property/__init__.py
+++ b/src/property/__init__.py
@@ -5,6 +5,7 @@ import bpy
 from .core import *
 from .datablocks import *
 from .templates import *
+from .preferences import *
 
 
 def register():
@@ -65,5 +66,7 @@ registration_targets = [
 	AF_PR_ImplementationValidationMessage,
 	AF_PR_Implementation,
 	AF_PR_ImplementationList,
-	AF_PR_AssetFetch
+	AF_PR_AssetFetch,
+	AF_PR_ProviderBookmarkPref,
+	AF_PR_Preferences
 ]

--- a/src/property/core.py
+++ b/src/property/core.py
@@ -5,6 +5,7 @@ from .updates import *
 from .templates import *
 from .datablocks import *
 from ..util.addon_constants import *
+from .preferences import *
 
 LOGGER = logging.getLogger("af.property.core")
 LOGGER.setLevel(logging.DEBUG)
@@ -356,8 +357,17 @@ class AF_PR_ImplementationList(bpy.types.PropertyGroup):
 
 # Final AssetFetch property
 
+def bookmarks_property_items(property, context):
+	prefs = AF_PR_Preferences.get_prefs()
+	out = [("none","None","No Bookmark")]
+	for c in prefs.provider_bookmarks:
+		if c.name:
+			out.append((c.name, c.name,c.init_url))
+	return out
 
 class AF_PR_AssetFetch(bpy.types.PropertyGroup):
+	provider_bookmark_selection: bpy.props.EnumProperty(name="Bookmark",items=bookmarks_property_items,update=update_bookmarks,description="Bookmark")
+
 	current_init_url: bpy.props.StringProperty(description="Init", update=update_init_url)
 	current_connection_state: bpy.props.PointerProperty(type=AF_PR_ConnectionStatus)
 	current_provider_initialization: bpy.props.PointerProperty(type=AF_PR_ProviderInitialization)

--- a/src/property/preferences.py
+++ b/src/property/preferences.py
@@ -7,15 +7,26 @@ class AF_PR_ProviderBookmarkPref(bpy.types.PropertyGroup):
 	header_values: bpy.props.CollectionProperty(type=AF_PR_GenericString)
 
 
-from ..ui.preferences import draw_preferences
 class AF_PR_Preferences(bpy.types.AddonPreferences):
 	bl_idname = ADDON_NAME
 
 	provider_bookmarks: bpy.props.CollectionProperty(type=AF_PR_ProviderBookmarkPref)
 	provider_bookmarks_index: bpy.props.IntProperty(default=0)
+	is_initialized: bpy.props.BoolProperty(default=False)
+
+	def __init__(self) -> None:
+		super().__init__()
 
 	def draw(self, context):
+
+		# TODO: This isn't the best place to put this!
+		if not self.is_initialized:
+			acg_bookmark = self.provider_bookmarks.add()
+			acg_bookmark.name="ambientCG"
+			acg_bookmark.init_url = "https://ambientcg.com/api/af/init"
+			self.is_initialized = True
+		from ..ui.preferences import draw_preferences
 		draw_preferences(self,context)
 
-#def addon_preferences() -> AF_PR_Preferences:
-#	return bpy.context.preferences.addons[ADDON_NAME].preferences
+def addon_preferences() -> AF_PR_Preferences:
+	return bpy.context.preferences.addons[ADDON_NAME].preferences

--- a/src/property/preferences.py
+++ b/src/property/preferences.py
@@ -14,19 +14,18 @@ class AF_PR_Preferences(bpy.types.AddonPreferences):
 	provider_bookmarks_index: bpy.props.IntProperty(default=0)
 	is_initialized: bpy.props.BoolProperty(default=False)
 
-	def __init__(self) -> None:
-		super().__init__()
-
 	def draw(self, context):
-
-		# TODO: This isn't the best place to put this!
-		if not self.is_initialized:
-			acg_bookmark = self.provider_bookmarks.add()
-			acg_bookmark.name="ambientCG"
-			acg_bookmark.init_url = "https://ambientcg.com/api/af/init"
-			self.is_initialized = True
 		from ..ui.preferences import draw_preferences
 		draw_preferences(self,context)
 
-def addon_preferences() -> AF_PR_Preferences:
-	return bpy.context.preferences.addons[ADDON_NAME].preferences
+	@staticmethod
+	def get_prefs():
+		prefs = bpy.context.preferences.addons[ADDON_NAME].preferences
+		if prefs:
+			# TODO: This isn't the best place to put this!
+			if not prefs.is_initialized:
+				acg_bookmark = prefs.provider_bookmarks.add()
+				acg_bookmark.name="ambientCG"
+				acg_bookmark.init_url = "https://ambientcg.com/api/af/init"
+				prefs.is_initialized = True
+		return prefs

--- a/src/property/preferences.py
+++ b/src/property/preferences.py
@@ -12,7 +12,11 @@ class AF_PR_Preferences(bpy.types.AddonPreferences):
 
 	provider_bookmarks: bpy.props.CollectionProperty(type=AF_PR_ProviderBookmarkPref)
 	provider_bookmarks_index: bpy.props.IntProperty(default=0)
+	provider_bookmarks_headers_index: bpy.props.IntProperty(default=0)
 	is_initialized: bpy.props.BoolProperty(default=False)
+
+	def get_current_bookmark_in_preferences(self) -> AF_PR_ProviderBookmarkPref | None :
+		return self.provider_bookmarks[self.provider_bookmarks_index]
 
 	def draw(self, context):
 		from ..ui.preferences import draw_preferences
@@ -24,8 +28,20 @@ class AF_PR_Preferences(bpy.types.AddonPreferences):
 		if prefs:
 			# TODO: This isn't the best place to put this!
 			if not prefs.is_initialized:
+
+				# ambientCG
 				acg_bookmark = prefs.provider_bookmarks.add()
 				acg_bookmark.name="ambientCG"
 				acg_bookmark.init_url = "https://ambientcg.com/api/af/init"
+
+				# Example
+				example_bookmark = prefs.provider_bookmarks.add()
+				example_bookmark.name="Advanced Python Example (see github.com/AssetFetch/examples)"
+				example_bookmark.init_url = "http://localhost:8001"
+				example_header = example_bookmark.header_values.add()
+				example_header.name = "access-token"
+				example_header.value = "debug"
+
+
 				prefs.is_initialized = True
 		return prefs

--- a/src/property/preferences.py
+++ b/src/property/preferences.py
@@ -1,0 +1,21 @@
+import bpy
+from .. import ADDON_NAME
+from .templates import *
+
+class AF_PR_ProviderBookmarkPref(bpy.types.PropertyGroup):
+	init_url: bpy.props.StringProperty(default="(URI)",description="The initialization URL for this provider.",name="URI")
+	header_values: bpy.props.CollectionProperty(type=AF_PR_GenericString)
+
+
+from ..ui.preferences import draw_preferences
+class AF_PR_Preferences(bpy.types.AddonPreferences):
+	bl_idname = ADDON_NAME
+
+	provider_bookmarks: bpy.props.CollectionProperty(type=AF_PR_ProviderBookmarkPref)
+	provider_bookmarks_index: bpy.props.IntProperty(default=0)
+
+	def draw(self, context):
+		draw_preferences(self,context)
+
+#def addon_preferences() -> AF_PR_Preferences:
+#	return bpy.context.preferences.addons[ADDON_NAME].preferences

--- a/src/property/updates.py
+++ b/src/property/updates.py
@@ -89,3 +89,11 @@ def update_variable_query_parameter(property, context):
 			update_asset_list_parameter(property, context)
 	else:
 		LOGGER.warn(f"No update_target on {property}")
+
+def update_bookmarks(property,context):
+	from .preferences import AF_PR_Preferences
+	LOGGER.debug("update_bookmarks")
+	prefs = AF_PR_Preferences.get_prefs()
+	selection = str(property.provider_bookmark_selection)
+	if selection != "none":
+		bpy.context.window_manager.af.current_init_url = prefs.provider_bookmarks[selection].init_url

--- a/src/property/updates.py
+++ b/src/property/updates.py
@@ -33,12 +33,15 @@ def update_init_url(property, context):
 def update_provider_header(property, context):
 	LOGGER.debug("update_provider_header")
 	if bpy.ops.af.connection_status.poll():
+		LOGGER.debug("Getting connection status...")
 		bpy.ops.af.connection_status()
 
 	if bpy.ops.af.update_asset_list.poll():
+		LOGGER.debug("Updating Asset List...")
 		bpy.ops.af.update_asset_list()
 
 	if bpy.ops.af.update_implementations_list.poll():
+		LOGGER.debug("Updating Implementation List...")
 		bpy.ops.af.update_implementations_list()
 
 

--- a/src/ui/__init__.py
+++ b/src/ui/__init__.py
@@ -22,6 +22,7 @@ registration_targets = [
 	AF_PT_AssetPanel,
 	AF_UL_ImplementationsItems,
 	AF_PT_ImplementationsPanel,
-	AF_UL_ProviderBookmarksItems
+	AF_UL_ProviderBookmarksItems,
+	AF_UL_ProviderBookmarksHeadersItems
 	#AF_PT_ImportStepsPanel
 ]

--- a/src/ui/__init__.py
+++ b/src/ui/__init__.py
@@ -3,7 +3,7 @@ from bpy.types import Context
 from .provider_panel import *
 from .asset_panel import *
 from .implementations_panel import *
-#from .import_steps_panel import *
+from .preferences import *
 
 
 def register():
@@ -22,6 +22,6 @@ registration_targets = [
 	AF_PT_AssetPanel,
 	AF_UL_ImplementationsItems,
 	AF_PT_ImplementationsPanel,
-	
+	AF_UL_ProviderBookmarksItems
 	#AF_PT_ImportStepsPanel
 ]

--- a/src/ui/preferences.py
+++ b/src/ui/preferences.py
@@ -15,6 +15,13 @@ class AF_UL_ProviderBookmarksItems(bpy.types.UIList):
 			row.label(text="(unnamed bookmark)")
 
 
+class AF_UL_ProviderBookmarksHeadersItems(bpy.types.UIList):
+
+	def draw_item(self, context, layout: bpy.types.UILayout, data, item: AF_PR_GenericString, icon, active_data, active_propname, index):
+		layout.prop(item, "name",text="Name")
+		layout.prop(item, "value",text="Value")
+
+
 def draw_preferences(self, context):
 	layout: bpy.types.UILayout = self.layout
 
@@ -31,13 +38,27 @@ def draw_preferences(self, context):
 		rows=3)
 
 	bookmarks_selection_actions = bookmarks_selection_row.column(align=True)
-	bookmarks_selection_actions.operator(operator="af.new_provider_bookmark",icon="ADD",text="")
-	bookmarks_selection_actions.operator(operator="af.delete_provider_bookmark",icon="REMOVE",text="")
+	bookmarks_selection_actions.operator(operator="af.new_provider_bookmark", icon="ADD", text="")
+	bookmarks_selection_actions.operator(operator="af.delete_provider_bookmark", icon="REMOVE", text="")
 
 	bookmarks.separator()
 	if len(self.provider_bookmarks) > 0:
 		bookmarks.prop(self.provider_bookmarks[self.provider_bookmarks_index], "name")
 		bookmarks.prop(self.provider_bookmarks[self.provider_bookmarks_index], "init_url")
+		bookmarks.label(text="Credentials")
+		bookmarks_header_config_row = bookmarks.row()
+		bookmarks_header_config_row.template_list(listtype_name="AF_UL_ProviderBookmarksHeadersItems",
+			list_id="name",
+			dataptr=self.provider_bookmarks[self.provider_bookmarks_index],
+			propname="header_values",
+			active_dataptr=self,
+			active_propname="provider_bookmarks_headers_index",
+			sort_lock=True,
+			rows=3)
+
+		bookmarks_header_config_actions_col = bookmarks_header_config_row.column(align=True)
+		bookmarks_header_config_actions_col.operator(operator="af.new_provider_bookmark_header", icon="ADD", text="")
+		bookmarks_header_config_actions_col.operator(operator="af.delete_provider_bookmark_header", icon="REMOVE", text="")
 	else:
 		bookmarks.label(text="Add a bookmark to edit it here!")
 

--- a/src/ui/preferences.py
+++ b/src/ui/preferences.py
@@ -1,0 +1,45 @@
+import bpy
+from .. import ADDON_NAME
+from ..property.templates import *
+from ..property.preferences import *
+
+
+class AF_UL_ProviderBookmarksItems(bpy.types.UIList):
+
+	def draw_item(self, context, layout: bpy.types.UILayout, data, item: AF_PR_ProviderBookmarkPref, icon, active_data, active_propname, index):
+		if item.name != "":
+			layout.label(text=item.name)
+		else:
+			row = layout.row()
+			row.enabled = False
+			row.label(text="(unnamed bookmark)")
+
+
+def draw_preferences(self, context):
+	layout: bpy.types.UILayout = self.layout
+
+	bookmarks = layout.column()
+	bookmarks.label(text="Bookmarks")
+	bookmarks_selection_row = bookmarks.row()
+	bookmarks_selection_row.template_list(listtype_name="AF_UL_ProviderBookmarksItems",
+		list_id="name",
+		dataptr=self,
+		propname="provider_bookmarks",
+		active_dataptr=self,
+		active_propname="provider_bookmarks_index",
+		sort_lock=True,
+		rows=3)
+
+	bookmarks_selection_actions = bookmarks_selection_row.column(align=True)
+	bookmarks_selection_actions.operator(operator="af.new_provider_bookmark",icon="ADD",text="")
+	bookmarks_selection_actions.operator(operator="af.delete_provider_bookmark",icon="REMOVE",text="")
+
+	bookmarks.separator()
+	if len(self.provider_bookmarks) > 0:
+		bookmarks.prop(self.provider_bookmarks[self.provider_bookmarks_index], "name")
+		bookmarks.prop(self.provider_bookmarks[self.provider_bookmarks_index], "init_url")
+	else:
+		bookmarks.label(text="Add a bookmark to edit it here!")
+
+	directories = layout.column()
+	directories.label(text="Directories")

--- a/src/ui/provider_panel.py
+++ b/src/ui/provider_panel.py
@@ -1,5 +1,5 @@
 import bpy
-
+from ..property.preferences import *
 
 class AF_PT_ProviderPanel(bpy.types.Panel):
 	bl_label = "Provider Selection"
@@ -19,6 +19,8 @@ class AF_PT_ProviderPanel(bpy.types.Panel):
 		info_box.label(text=f"Download directory: {af.download_directory}")
 		info_box.label(text=f"Icon directory: {af.ui_image_directory}")
 		info_box.label(text="Unstable & lacking numerous features, use with caution & patience!")
+
+		layout.prop(af,"provider_bookmark_selection")
 
 		# Add a text box to enter the URL
 		layout.prop(context.window_manager.af, "current_init_url", text="Provider URL", icon="URL")

--- a/src/ui/provider_panel.py
+++ b/src/ui/provider_panel.py
@@ -23,7 +23,10 @@ class AF_PT_ProviderPanel(bpy.types.Panel):
 		layout.prop(af,"provider_bookmark_selection")
 
 		# Add a text box to enter the URL
-		layout.prop(context.window_manager.af, "current_init_url", text="Provider URL", icon="URL")
+		row = layout.row()
+		if af['provider_bookmark_selection'] > 0:
+			row.enabled = False
+		row.prop(context.window_manager.af, "current_init_url", text="Provider URL", icon="URL")
 
 		# Add a button to get the vendor info
 		#layout.operator("af.initialize_provider", text="Initialize")
@@ -32,8 +35,11 @@ class AF_PT_ProviderPanel(bpy.types.Panel):
 		if len(af.current_provider_initialization.provider_configuration.headers.values()) > 0:
 
 			for provider_header in af.current_provider_initialization.provider_configuration.headers.values():
-				layout.prop(provider_header, "value", text=provider_header.title)
-			#layout.operator("af.connection_status",text="Connect")
+				col = layout.column()
+				col.prop(provider_header, "value", text=provider_header.title)
+				#layout.operator("af.connection_status",text="Connect")
+				if af['provider_bookmark_selection'] > 0:
+					col.enabled = False
 
 		connection_state_icons = {"pending": "SEQUENCE_COLOR_09", "awaiting_input": "SEQUENCE_COLOR_03", "connection_error": "SEQUENCE_COLOR_01", "connected": "SEQUENCE_COLOR_04"}
 


### PR DESCRIPTION
This PR adds a bookmark system (accessible via Preferences) where bookmarks for providers can be stored and later retrieved so that it is no longer necessary to manually type in the provider URL every time.

![image](https://github.com/struffel/assetfetch-blender/assets/31403260/2dd2ca97-e277-49eb-8ae6-8f37ba10c98c)
